### PR TITLE
Add koreader to the Gnome dash

### DIFF
--- a/overlays/gnome_config/01-pinenote-settings
+++ b/overlays/gnome_config/01-pinenote-settings
@@ -49,7 +49,7 @@ visual-bell=false
 
 [org/gnome/shell]
 enabled-extensions=['pnhelper@m-weigand.github.com', 'user-theme@gnome-shell-extensions.gcampax.github.com']
-favorite-apps=['org.gnome.Terminal.desktop', 'org.gnome.Nautilus.desktop', 'firefox-esr.desktop', 'com.github.johnfactotum.Foliate.desktop', 'com.github.xournalpp.xournalpp.desktop', 'libreoffice-writer.desktop']
+favorite-apps=['org.gnome.Terminal.desktop', 'org.gnome.Nautilus.desktop', 'firefox-esr.desktop', 'com.github.johnfactotum.Foliate.desktop', 'com.github.xournalpp.xournalpp.desktop', 'libreoffice-writer.desktop', 'koreader.desktop']
 
 [shell/extensions/user-theme]
 name='PNEink'


### PR DESCRIPTION
Located in `/usr/share/applications/koreader.desktop`