### PR TITLE
fix shebang

### DIFF
--- a/overlays/custom_debs/pin_custom_debs.sh
+++ b/overlays/custom_debs/pin_custom_debs.sh
@@ -1,4 +1,4 @@
-#/usr/bin/env bash
+#!/usr/bin/env bash
 # hold/pin custom-installed packages
 set -eux -o pipefail
 


### PR DESCRIPTION
This was causing an error if you tried to run this on something besides bash. See https://stackoverflow.com/questions/54055549/linux-ubuntu-set-illegal-option-o-pipefail