### PR TITLE
WIP: add preliminary sway setup

### DIFF
--- a/09_sway.yaml
+++ b/09_sway.yaml
@@ -13,6 +13,7 @@ actions:
     description: Install sway and related packages
     packages:
       - brightnessctl
+      - fonts-font-awesome
       - fonts-noto-color-emoji
       - fonts-noto-hinted
       - foot
@@ -23,6 +24,7 @@ actions:
       - python3-pydbus
       - sway
       - swayidle
+      - waybar
       - wtype
 
   - action: overlay

--- a/09_sway.yaml
+++ b/09_sway.yaml
@@ -1,0 +1,49 @@
+{{- $architecture := or .architecture "arm64" -}}
+{{- $prevtargz := .prevtargz }}
+{{- $targz := .targz }}
+
+architecture: {{ $architecture }}
+
+actions:
+  - action: unpack
+    file: {{ $prevtargz }}
+
+  - action: apt
+    recommends: false
+    description: Install sway and related packages
+    packages:
+      - brightnessctl
+      - fonts-noto-color-emoji
+      - fonts-noto-hinted
+      - foot
+      - iio-sensor-proxy
+      - jq
+      - lisgd
+      - python3-i3ipc
+      - python3-pydbus
+      - sway
+      - swayidle
+      - wtype
+
+  - action: overlay
+    description: Binaries for sway environment
+    source: overlays/sway_config/bin/
+    destination: /usr/local/bin/
+
+  - action: overlay
+    description: Pinned entries for nwg-menu
+    source: overlays/sway_config/cache/nwg-pin-cache
+    destination: /etc/skel/.cache/
+
+  - action: overlay
+    description: Configuration for sway
+    source: overlays/sway_config/sway/
+    destination: /etc/skel/.config/sway/
+
+  - action: overlay
+    description: Configuration for waybar
+    source: overlays/sway_config/waybar/
+    destination: /etc/skel/.config/waybar/
+
+  - action: pack
+    file: {{ $targz }}

--- a/overlays/sway_config/bin/after_resume.sh
+++ b/overlays/sway_config/bin/after_resume.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+brightnessctl --restore --device=backlight_warm
+brightnessctl --restore --device=backlight_cool
+killall imv-wayland

--- a/overlays/sway_config/bin/before_sleep.sh
+++ b/overlays/sway_config/bin/before_sleep.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+brightnessctl --save --device backlight_cool set 0
+brightnessctl --save --device backlight_warm set 0
+imv -f /etc/off_and_suspend_screen/Pinenotebg4.png

--- a/overlays/sway_config/bin/ebc_bw_set
+++ b/overlays/sway_config/bin/ebc_bw_set
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+bw_mode_file=/sys/module/rockchip_ebc/parameters/bw_mode
+default_waveform_file=/sys/module/rockchip_ebc/parameters/default_waveform
+echo "$1" >"${bw_mode_file}"
+
+if [ $(cat "${bw_mode_file}") = 0 ]; then
+  echo 7 > "${default_waveform_file}"
+  #refresh_screen
+else
+  echo 1 > "${default_waveform_file}"
+fi

--- a/overlays/sway_config/bin/ebc_toggle_bw
+++ b/overlays/sway_config/bin/ebc_toggle_bw
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+bw_mode_file=/sys/module/rockchip_ebc/parameters/bw_mode
+default_waveform_file=/sys/module/rockchip_ebc/parameters/default_waveform
+tr 012 120 <"${bw_mode_file}" >"${bw_mode_file}"
+
+if [ $(cat "${bw_mode_file}") = 0 ]; then
+  echo 7 > "${default_waveform_file}"
+  #refresh_screen
+else
+  echo 1 > "${default_waveform_file}"
+fi

--- a/overlays/sway_config/bin/import-gsettings
+++ b/overlays/sway_config/bin/import-gsettings
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+# Source: https://github.com/swaywm/sway/wiki/GTK-3-settings-on-Wayland
+
+# usage: import-gsettings
+config="${XDG_CONFIG_HOME:-$HOME/.config}/gtk-3.0/settings.ini"
+if [ ! -f "$config" ]; then exit 1; fi
+
+gnome_schema="org.gnome.desktop.interface"
+gtk_theme="$(grep 'gtk-theme-name' "$config" | sed 's/.*\s*=\s*//')"
+icon_theme="$(grep 'gtk-icon-theme-name' "$config" | sed 's/.*\s*=\s*//')"
+cursor_theme="$(grep 'gtk-cursor-theme-name' "$config" | sed 's/.*\s*=\s*//')"
+font_name="$(grep 'gtk-font-name' "$config" | sed 's/.*\s*=\s*//')"
+gsettings set "$gnome_schema" gtk-theme "$gtk_theme"
+gsettings set "$gnome_schema" icon-theme "$icon_theme"
+gsettings set "$gnome_schema" cursor-theme "$cursor_theme"
+gsettings set "$gnome_schema" font-name "$font_name"

--- a/overlays/sway_config/bin/launch_lisgd.sh
+++ b/overlays/sway_config/bin/launch_lisgd.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+
+killall lisgd || true 
+lisgd -d /dev/input/by-path/platform-fe5e0000.i2c-event \
+    -g "4,DU,*,*,R,xournalpp &" \
+    -g "3,DU,*,*,R,toggle_onscreen_keyboard.py &" \
+    -g "3,UD,*,*,R,refresh_screen &" \
+    -g "3,LR,*,*,R,sway_workspace goto prev &" \
+    -g "3,RL,*,*,R,sway_workspace goto next &" \
+    -g "4,LR,*,*,R,sway_workspace move prev &" \
+    -g "4,RL,*,*,R,sway_workspace move next &" \
+    -g "4,UD,*,*,R,toggle_menu.sh &" &

--- a/overlays/sway_config/bin/refresh_screen
+++ b/overlays/sway_config/bin/refresh_screen
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+dbus-send --system --print-reply --dest=org.pinenote.ebc /ebc org.pinenote.ebc.TriggerGlobalRefresh

--- a/overlays/sway_config/bin/sway_rotate.sh
+++ b/overlays/sway_config/bin/sway_rotate.sh
@@ -1,0 +1,51 @@
+#!/bin/sh
+
+focusedtransform() {
+	swaymsg -t get_outputs | jq -r '.[] | select(.focused == true) | .transform'
+}
+
+focusedname() {
+	swaymsg -t get_outputs | jq -r '.[] | select(.focused == true) | .name'
+}
+
+startlisgd() {
+  launch_lisgd.sh
+}
+
+rotnormal() {
+	swaymsg -- output "-" transform 0 scale 1
+	focused_name="$(focusedname)"
+	swaymsg -- input type:touch map_to_output "$focused_name"
+	swaymsg -- input type:tablet_tool map_to_output "$focused_name"
+	startlisgd 0
+	exit 0
+}
+
+rotleft() {
+	swaymsg -- output "-" transform 90 scale 1
+	focused_name="$(focusedname)"
+	swaymsg -- input type:touch map_to_output "$focused_name"
+	swaymsg -- input type:tablet_tool map_to_output "$focused_name"
+	startlisgd 3
+	exit 0
+}
+
+rotright() {
+	swaymsg -- output "-" transform 270 scale 1
+	focused_name="$(focusedname)"
+	swaymsg -- input type:touch map_to_output "$focused_name"
+	swaymsg -- input type:tablet_tool map_to_output "$focused_name"
+	startlisgd 1
+	exit 0
+}
+
+rotinvert() {
+	swaymsg -- output "-" transform 180 scale 1
+	focused_name="$(focusedname)"
+	swaymsg -- input type:touch map_to_output "$focused_name"
+	swaymsg -- input type:tablet_tool map_to_output "$focused_name"
+	startlisgd 2
+	exit 0
+}
+
+"$@"

--- a/overlays/sway_config/bin/sway_waveform.py
+++ b/overlays/sway_config/bin/sway_waveform.py
@@ -1,0 +1,89 @@
+#!/usr/bin/env python3
+from enum import Enum
+import pathlib
+
+import i3ipc
+
+class Waveform(Enum):
+    RESET = 0
+    A2 = 1
+    DU = 2
+    DU4 = 3
+    GC16 = 4
+    GCC16 = 5
+    GL16 = 6
+    GLR16 = 7
+    GLD16 = 8
+
+
+class BWMode(Enum):
+    GREY = 0
+    DITHERING = 1
+    THRESHOLDING = 2
+
+class Preset(Enum):
+    A2_DITHERING = 0
+    GC16_GREY = 1
+
+presets = {
+    Preset.A2_DITHERING: (Waveform.A2, BWMode.DITHERING),
+    Preset.GC16_GREY: (Waveform.GC16, BWMode.GREY),
+}
+
+class EDCManager:
+
+    def __init__(self):
+        param_dir = pathlib.Path('/sys/module/rockchip_ebc/parameters/')
+        self.default_waveform = param_dir / 'default_waveform'
+        self.bw_mode = param_dir / 'bw_mode'
+
+    def get_waveform(self) -> Waveform:
+        return Waveform(int(self.default_waveform.read_text()))
+
+    def set_waveform(self, waveform: Waveform):
+        self.default_waveform.write_text(str(waveform.value))
+
+    def get_bw_mode(self) -> BWMode:
+        return BWMode(int(self.bw_mode.read_text()))
+
+    def set_bw_mode(self, bw_mode: BWMode):
+        self.bw_mode.write_text(str(bw_mode.value))
+
+    def use_preset(self, preset: Preset):
+        waveform, bw_mode = presets[preset]
+        self.set_waveform(waveform)
+        self.set_bw_mode(bw_mode)
+        print('Using preset', preset)
+
+class Monitor:
+    def __init__(self):
+        self.last_app_id = None
+        self.edc_manager = EDCManager()
+        self.conn = i3ipc.Connection()
+        self.conn.on('window::focus', self.focus_change)
+
+    def focus_change(self, i3conn, event):
+        app_id = event.container.app_id
+        print('focus change', app_id)
+        if app_id != self.last_app_id:
+            match app_id:
+                case 'KOReader':
+                    self.edc_manager.use_preset(Preset.GC16_GREY)
+                case 'xournalpp':
+                    self.edc_manager.use_preset(Preset.A2_DITHERING)
+                case _:
+                    self.edc_manager.use_preset(Preset.A2_DITHERING)
+            self.last_app_id = app_id
+
+    def run(self):
+        try:
+            self.conn.main()
+        except KeyboardInterrupt:
+            print('Exiting')
+
+def main():
+    m = Monitor()
+    m.run()
+
+if __name__ == '__main__':
+    main()

--- a/overlays/sway_config/bin/sway_workspace
+++ b/overlays/sway_config/bin/sway_workspace
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+set -ef
+
+ws=$(swaymsg -t get_workspaces |jq '.[] | select((.output == "DPI-1") and .focused) | .num')
+if [[ $2 == "next" ]]; then
+	new_ws="$(echo "$ws" | tr 123 231)"
+	if [[ $1 == "goto" ]]; then
+		swaymsg workspace "$new_ws"
+	elif [[ $1 == "move" ]]; then
+		swaymsg move window to workspace "$new_ws"
+	fi
+elif [[ $2 == "prev" ]]; then
+	new_ws="$(echo "$ws" | tr 123 312)"
+	if [[ $1 == "goto" ]]; then
+		swaymsg workspace "$new_ws"
+	elif [[ $1 == "move" ]]; then
+		swaymsg move window to workspace "$new_ws"
+	fi
+else
+	exit 1
+fi

--- a/overlays/sway_config/bin/toggle_menu.sh
+++ b/overlays/sway_config/bin/toggle_menu.sh
@@ -1,0 +1,3 @@
+#!/bin/sh
+
+nwg-menu -fm pcmanfm -term foot -va top -isl 64 -iss 64 &

--- a/overlays/sway_config/bin/toggle_onscreen_keyboard.py
+++ b/overlays/sway_config/bin/toggle_onscreen_keyboard.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+
+from pydbus import SessionBus
+import os
+import time
+
+bus = SessionBus()
+
+try:
+    okb = bus.get("sm.puri.OSK0")
+except Exception:
+    os.system("nohup squeekboard &")
+    time.sleep(1)
+    okb = bus.get("sm.puri.OSK0")
+
+okb.SetVisible(not okb.Visible)

--- a/overlays/sway_config/cache/nwg-pin-cache
+++ b/overlays/sway_config/cache/nwg-pin-cache
@@ -1,0 +1,3 @@
+com.github.xournalpp.xournalpp.desktop
+koreader.desktop
+org.codeberg.dnkl.foot.desktop

--- a/overlays/sway_config/sway/colorscheme
+++ b/overlays/sway_config/sway/colorscheme
@@ -1,0 +1,2 @@
+set $black #000000
+set $white #ffffff

--- a/overlays/sway_config/sway/config
+++ b/overlays/sway_config/sway/config
@@ -1,0 +1,242 @@
+# Default config for sway
+#
+# Copy this to ~/.config/sway/config and edit it to your liking.
+#
+# Read `man 5 sway` for a complete reference.
+
+# Unlike Mod4 (logo key), Mod1 (Alt) works with squeekboard without custom layout
+set $mod Mod1
+
+# Home row direction keys, like vim
+set $left h
+set $down j
+set $up k
+set $right l
+
+# Your preferred terminal emulator
+set $term foot
+
+set $menu "toggle_menu.sh"
+
+font pango:Noto Sans 20
+
+### Output configuration
+output * bg #FFFFFF solid_color
+output * scale 1
+
+gaps inner 5
+gaps outer 0
+smart_gaps on
+
+default_border normal
+default_floating_border normal
+
+# Property Name         Border  BG      Text    Indicator Child Border
+include colorscheme
+client.focused          $white $black $white
+client.focused_inactive $black $white $black
+client.unfocused        $white $white $black
+client.urgent           $black $white $black
+
+### Idle configuration
+#
+# Example configuration:
+#
+# exec swayidle -w \
+#          timeout 300 'swaylock -f -c 000000' \
+#          timeout 600 'swaymsg "output * dpms off"' resume 'swaymsg "output * dpms on"' \
+#          before-sleep 'swaylock -f -c 000000'
+#
+# This will lock your screen after 300 seconds of inactivity, then turn off
+# your displays after another 300 seconds, and turn your screens back on when
+# resumed. It will also lock your screen before your computer goes to sleep.
+exec_always --no-startup-id flock -n .swayidle.lock swayidle timeout 600 "systemctl suspend" before-sleep "before_sleep.sh" after-resume "after_resume.sh"
+
+### Input configuration
+#
+# Example configuration:
+#
+#   input "2:14:SynPS/2_Synaptics_TouchPad" {
+#       dwt enabled
+#       tap enabled
+#       natural_scroll enabled
+#       middle_emulation enabled
+#   }
+#
+# You can get the names of your inputs by running: swaymsg -t get_inputs
+# Read `man 5 sway-input` for more information about this section.
+input "0:0:cyttsp5" map_to_output "DPI-1"
+input "11551:149:w9013_2D1F:0095_Stylus" map_to_output "DPI-1"
+
+### Key bindings
+#
+# Basics:
+#
+    # Start a terminal
+    bindsym $mod+Return exec $term
+
+    # Kill focused window
+    bindsym $mod+Shift+q kill
+
+    # Start your launcher
+    bindsym $mod+d exec $menu
+
+    # Drag floating windows by holding down $mod and left mouse button.
+    # Resize them with right mouse button + $mod.
+    # Despite the name, also works for non-floating windows.
+    # Change normal to inverse to use left mouse button for resizing and right
+    # mouse button for dragging.
+    floating_modifier $mod normal
+
+    # Reload the configuration file
+    bindsym $mod+Shift+c reload
+
+    # Exit sway (logs you out of your Wayland session)
+    bindsym $mod+Shift+e exec swaynag -t warning -m 'You pressed the exit shortcut. Do you really want to exit sway? This will end your Wayland session.' -B 'Yes, exit sway' 'swaymsg exit'
+#
+# Moving around:
+#
+    # Move your focus around
+    bindsym $mod+$left focus left
+    bindsym $mod+$down focus down
+    bindsym $mod+$up focus up
+    bindsym $mod+$right focus right
+    # Or use $mod+[up|down|left|right]
+    bindsym $mod+Left focus left
+    bindsym $mod+Down focus down
+    bindsym $mod+Up focus up
+    bindsym $mod+Right focus right
+
+    # Move the focused window with the same, but add Shift
+    bindsym $mod+Shift+$left move left
+    bindsym $mod+Shift+$down move down
+    bindsym $mod+Shift+$up move up
+    bindsym $mod+Shift+$right move right
+    # Ditto, with arrow keys
+    bindsym $mod+Shift+Left move left
+    bindsym $mod+Shift+Down move down
+    bindsym $mod+Shift+Up move up
+    bindsym $mod+Shift+Right move right
+#
+# Workspaces:
+#
+    # Switch to workspace
+    bindsym $mod+1 workspace number 1
+    bindsym $mod+2 workspace number 2
+    bindsym $mod+3 workspace number 3
+    bindsym $mod+4 workspace number 4
+    bindsym $mod+5 workspace number 5
+    bindsym $mod+6 workspace number 6
+    bindsym $mod+7 workspace number 7
+    bindsym $mod+8 workspace number 8
+    bindsym $mod+9 workspace number 9
+    bindsym $mod+0 workspace number 10
+    # Move focused container to workspace
+    bindsym $mod+Shift+1 move container to workspace number 1
+    bindsym $mod+Shift+2 move container to workspace number 2
+    bindsym $mod+Shift+3 move container to workspace number 3
+    bindsym $mod+Shift+4 move container to workspace number 4
+    bindsym $mod+Shift+5 move container to workspace number 5
+    bindsym $mod+Shift+6 move container to workspace number 6
+    bindsym $mod+Shift+7 move container to workspace number 7
+    bindsym $mod+Shift+8 move container to workspace number 8
+    bindsym $mod+Shift+9 move container to workspace number 9
+    bindsym $mod+Shift+0 move container to workspace number 10
+    # Note: workspaces can have any name you want, not just numbers.
+    # We just use 1-10 as the default.
+#
+# Layout stuff:
+#
+    # You can "split" the current object of your focus with
+    # $mod+b or $mod+v, for horizontal and vertical splits
+    # respectively.
+    bindsym $mod+b splith
+    bindsym $mod+v splitv
+
+    # Switch the current container between different layout styles
+    bindsym $mod+s layout stacking
+    bindsym $mod+w layout tabbed
+    bindsym $mod+e layout toggle split
+
+    # Make the current focus fullscreen
+    bindsym $mod+f fullscreen
+
+    # Toggle the current focus between tiling and floating mode
+    bindsym $mod+Shift+space floating toggle
+
+    # Swap focus between the tiling area and the floating area
+    bindsym $mod+space focus mode_toggle
+
+    # Move focus to the parent container
+    bindsym $mod+a focus parent
+#
+# Scratchpad:
+#
+    # Sway has a "scratchpad", which is a bag of holding for windows.
+    # You can send windows there and get them back later.
+
+    # Move the currently focused window to the scratchpad
+    bindsym $mod+Shift+minus move scratchpad
+
+    # Show the next scratchpad window or hide the focused scratchpad window.
+    # If there are multiple scratchpad windows, this command cycles through them.
+    bindsym $mod+minus scratchpad show
+#
+# Resizing containers:
+#
+mode "resize" {
+    # left will shrink the containers width
+    # right will grow the containers width
+    # up will shrink the containers height
+    # down will grow the containers height
+    bindsym $left resize shrink width 10px
+    bindsym $down resize grow height 10px
+    bindsym $up resize shrink height 10px
+    bindsym $right resize grow width 10px
+
+    # Ditto, with arrow keys
+    bindsym Left resize shrink width 10px
+    bindsym Down resize grow height 10px
+    bindsym Up resize shrink height 10px
+    bindsym Right resize grow width 10px
+
+    # Return to default mode
+    bindsym Return mode "default"
+    bindsym Escape mode "default"
+}
+bindsym $mod+r mode "resize"
+
+#
+# Status Bar:
+#
+# Read `man 5 sway-bar` for more information about this section.
+# bar {
+#     position top
+# 
+#     # When the status_command prints a new line to stdout, swaybar updates.
+#     # The default just shows the current date and time.
+#     status_command while date +'%Y-%m-%d %I:%M:%S %p'; do sleep 1; done
+# 
+#     colors {
+#         statusline #ffffff
+#         background #323232
+#         inactive_workspace #32323200 #32323200 #5c5c5c
+#     }
+# }
+
+bar {
+    position top
+    swaybar_command waybar
+}
+
+exec --no-startup-id nm-applet --indicator &
+exec --no-startup-id squeekboard & 
+
+# exec_always import-gsettings
+exec --no-startup-id sway_rotate.sh rotnormal
+
+exec_always --no-startup-id launch_lisgd.sh
+exec sway_waveform.py
+exec rot8 --hooks launch_lisgd.sh --display DPI-1 --invert-x
+
+include /etc/sway/config.d/*

--- a/overlays/sway_config/waybar/config
+++ b/overlays/sway_config/waybar/config
@@ -1,0 +1,409 @@
+// =============================================================================
+//
+// Waybar configuration
+//
+// Configuration reference: https://github.com/Alexays/Waybar/wiki/Configuration
+//
+// =============================================================================
+
+{
+    // -------------------------------------------------------------------------
+    // Global configuration
+    // -------------------------------------------------------------------------
+
+    "layer": "top",
+
+    "position": "top",
+
+    // If height property would be not present, it'd be calculated dynamically
+    "height": 40,
+
+    "modules-left": [
+      "custom/smenu",
+      "custom/okb",
+      // "custom/rotate_0",
+      // "custom/rotate_90",
+      // "custom/winleft",
+      // "custom/winup",
+      "custom/windown",
+      "custom/winright",
+      "custom/ws1",
+      "custom/ws2",
+      // "custom/ws3",
+      // "custom/movetows1",
+      // "custom/movetows2",
+      "custom/movetows3",
+      // "custom/rotate_270",
+      "custom/rotate_180",
+    ],
+    "modules-center": [
+        "sway/mode",
+        "custom/blc_down",
+        "custom/blc_up",
+        "custom/blw_down",
+        "custom/blw_up",
+        // "custom/ebc_reload",
+        // "custom/key_pagedown",
+        // "custom/key_pageup",
+        "custom/ebc_bw1",
+        "custom/ebc_bw2",
+        "custom/ebc_bw3",
+        "idle_inhibitor",
+    ],
+    "modules-right": [
+        //"custom/battery_watts",
+        //"cpu",
+        //"memory",
+        //"temperature",
+        "battery",
+        "tray",
+        // "clock#time",
+        "custom/kill",
+    ],
+
+
+    // -------------------------------------------------------------------------
+    // Modules
+    // -------------------------------------------------------------------------
+
+    "battery": {
+        "bat": "rk817-battery",
+        "name": "battery",
+        "interval": 10,
+        "states": {
+            "warning": 30,
+            "critical": 15
+        },
+        // Connected to AC
+        "format": " {icon} {capacity}%", // Icon: bolt
+        // Not connected to AC
+        "format-discharging": "{capacity}% {icon}",
+        "format-icons": [
+            "", // Icon: battery-full
+            "", // Icon: battery-three-quarters
+            "", // Icon: battery-half
+            "", // Icon: battery-quarter
+            ""  // Icon: battery-empty
+        ],
+        "tooltip": true
+    },
+
+    "clock#time": {
+        "interval": 1,
+        "format": "{:%H:%M}",
+        "tooltip": false
+    },
+
+    "clock#date": {
+      "interval": 10,
+      "format": "  {:%e %b %Y}", // Icon: calendar-alt
+      "tooltip-format": "{:%e %B %Y}"
+    },
+
+    "cpu": {
+        "interval": 5,
+        "format": "  {usage}%", // Icon: microchip
+        "states": {
+          "warning": 70,
+          "critical": 90
+        }
+    },
+
+    "memory": {
+        "interval": 5,
+        "format": "  {}%", // Icon: memory
+        "states": {
+            "warning": 70,
+            "critical": 90
+        }
+    },
+
+    "sway/mode": {
+        "format": "<span style=\"italic\">  {}</span>", // Icon: expand-arrows-alt
+        "tooltip": false
+    },
+
+    "sway/window": {
+        "format": "{}",
+        "max-length": 120
+    },
+
+    "temperature": {
+      "critical-threshold": 80,
+      "interval": 5,
+      "format": "{icon}  {temperatureC}°C",
+      "format-icons": [
+          "", // Icon: temperature-empty
+          "", // Icon: temperature-quarter
+          "", // Icon: temperature-half
+          "", // Icon: temperature-three-quarters
+          ""  // Icon: temperature-full
+      ],
+      "tooltip": true,
+      "hwmon-path": "/sys/class/hwmon/hwmon3/temp1_input",
+    },
+
+    "custom/kill": {
+      "format": "",
+      "interval": "once",
+      "on-click": "swaymsg kill",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/winleft": {
+      "format": "",
+      "interval": "once",
+      "on-click": "swaymsg move left",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/winright": {
+      "format": "",
+      "interval": "once",
+      "on-click": "swaymsg move right",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/winup": {
+      "format": "",
+      "interval": "once",
+      "on-click": "swaymsg move up",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/windown": {
+      "format": "",
+      "interval": "once",
+      "on-click": "swaymsg move down",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/movetows1": {
+      "format": "1",
+      "interval": "once",
+      "on-click": "swaymsg move container to workspace number 1",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/movetows2": {
+      "format": "2",
+      "interval": "once",
+      "on-click": "swaymsg move container to workspace number 2",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/movetows3": {
+      "format": "3",
+      "interval": "once",
+      "on-click": "swaymsg move container to workspace number 3",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/movetows4": {
+      "format": "4",
+      "interval": "once",
+      "on-click": "swaymsg move container to workspace number 4",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/movetows5": {
+      "format": "5",
+      "interval": "once",
+      "on-click": "swaymsg move container to workspace number 5",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/okb": {
+      "format": "",
+      "interval": "once",
+      "on-click": "toggle_onscreen_keyboard.py",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/smenu": {
+      "format": "",
+      "interval": "once",
+      "on-click": "toggle_menu.sh",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/ws1": {
+      "format": "1",
+      "interval": "once",
+      "on-click": "swaymsg workspace number 1",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/ws2": {
+      "format": "2",
+      "interval": "once",
+      "on-click": "swaymsg workspace number 2",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/ws3": {
+      "format": "3",
+      "interval": "once",
+      "on-click": "swaymsg workspace number 3",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/ws4": {
+      "format": "4",
+      "interval": "once",
+      "on-click": "swaymsg workspace number 4",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/ws5": {
+      "format": "5",
+      "interval": "once",
+      "on-click": "swaymsg workspace number 5",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/blc_down": {
+      "format": "",
+      "interval": "once",
+      "on-click": "brightnessctl --device=backlight_cool set 10%-",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/blc_up": {
+      "format": "",
+      "interval": "once",
+      "on-click": "brightnessctl --device=backlight_cool set 10%+",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/blw_down": {
+      "format": "",
+      "interval": "once",
+      "on-click": "brightnessctl --device=backlight_warm set 10%-",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/blw_up": {
+      "format": "",
+      "interval": "once",
+      "on-click": "brightnessctl --device=backlight_warm set 10%+",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/ebc_bw1": {
+      "format": "1️⃣",
+      "interval": "once",
+      "on-click": "ebc_bw_set 0",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/ebc_bw2": {
+      "format": "2️⃣",
+      "interval": "once",
+      "on-click": "ebc_bw_set 1",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/ebc_bw3": {
+      "format": "3️⃣",
+      "interval": "once",
+      "on-click": "ebc_bw_set 2",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/ebc_bw": {
+      "format": "⬜",
+      "interval": "once",
+      "on-click": "ebc_toggle_bw",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "idle_inhibitor": {
+      "format": "{icon}",
+      "format-icons": {
+        "activated": "",
+        "deactivated": ""
+      }
+    },
+
+    "custom/ebc_reload": {
+      "format": "",
+      "interval": "once",
+      "on-click": "refresh_screen",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/rotate_0": {
+      "format": "R0",
+      "interval": "once",
+      "on-click": "sway_rotate.sh rotnormal",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/rotate_90": {
+      "format": "R90",
+      "interval": "once",
+      "on-click": "sway_rotate.sh rotright",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/rotate_180": {
+      "format": "R180",
+      "interval": "once",
+      "on-click": "sway_rotate.sh rotinvert",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/rotate_270": {
+      "format": "R270",
+      "interval": "once",
+      "on-click": "sway_rotate.sh rotleft",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/key_pageup": {
+      "format": "",
+      "interval": "once",
+      // "on-click": "wtype -P page_up",
+      "on-click": "swaymsg resize grow width 10px; swaymsg resize grow height 10px",
+      "min-length": 5,
+      "tooltip": false,
+    },
+    "custom/key_pagedown": {
+      "format": "",
+      "interval": "once",
+      // "on-click": "wtype -P page_down",
+      "on-click": "swaymsg resize shrink width 10px; swaymsg resize shrink height 10px",
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "custom/battery_watts": {
+      "exec": "battery_watts.sh",
+      "format": " {}W",
+      "interval": 10,
+      "min-length": 5,
+      "tooltip": false,
+    },
+
+    "tray": {
+        "icon-size": 21,
+        "spacing": 10
+    }
+
+}

--- a/overlays/sway_config/waybar/style.css
+++ b/overlays/sway_config/waybar/style.css
@@ -1,0 +1,33 @@
+* {
+	border: none;
+	border-radius: 0;
+	font-size: 22px;
+}
+
+#workspaces {
+	padding: 0 0px;
+	margin: 0 0px;
+}
+
+window#waybar {
+	background: #000000;
+	color: #ffffff;
+}
+
+button {
+	padding: 0 0px;
+	margin: 0 0px;
+	background: transparent;
+	color: #ffffff;
+}
+
+.battery {
+	padding: 0 10px;
+}
+
+button {
+	padding: 0 0px;
+	margin: 0 0px;
+	background: transparent;
+	color: #ffffff;
+}

--- a/recipes-pipeline
+++ b/recipes-pipeline
@@ -8,6 +8,7 @@
 06_finalsetup.yaml
 07_gnome.yaml
 08_custom_debs.yaml
+09_sway.yaml
 11_adduser.yaml
 # If you build locally, in a docker container, sometimes errors occurred while
 # creating the disc image. Therefore, in those cases, comment out the next two


### PR DESCRIPTION
See also #92.

Missing:
- [ ] Package nwg-menu: graphical launcher
- [ ] Package rot8: automatically rotate output based on acceleration events
- [ ] Add icon system-reboot for nwg-menu or use another theme like Papirus
- [ ] Test pipeline
- [ ] Test result: I've been using a manual setup that I copied together from my arch linux installation
- [ ] lisgd configuration: add support for 2-finger panels. At the moment only 3 and 4 finger gestures are configured, which work with my own PineNote and the newest batch
- [ ] Adjust sizes and styles
