### PR TITLE
greetd: add configuration files and helper for gnome session

### DIFF
--- a/overlays/greetd/bin/gnome-run
+++ b/overlays/greetd/bin/gnome-run
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+export XDG_SESSION_TYPE=wayland
+exec dbus-run-session gnome-session

--- a/overlays/greetd/etc_greetd/config.toml
+++ b/overlays/greetd/etc_greetd/config.toml
@@ -1,0 +1,23 @@
+[terminal]
+# The VT to run the greeter on. Can be "next", "current" or a number
+# designating the VT.
+vt = 7
+
+# Automatic login at boot, but not for subsequent sessions
+[initial_session]
+user = "user"
+command = "gnome-run"
+
+# The default session, also known as the greeter.
+[default_session]
+
+# `agreety` is the bundled agetty/login-lookalike. You can replace `/bin/sh`
+# with whatever you want started, such as `sway`.
+# command = "cage -s -- regreet"
+# if using wlgreet
+command = "sway --config /etc/greetd/sway-config"
+
+# The user to run the command as. The privileges this user must have depends
+# on the greeter. A graphical greeter may for example require the user to be
+# in the `video` group.
+user = "_greetd"

--- a/overlays/greetd/etc_greetd/environments
+++ b/overlays/greetd/etc_greetd/environments
@@ -1,0 +1,1 @@
+gnome-run

--- a/overlays/greetd/etc_greetd/sway-config
+++ b/overlays/greetd/etc_greetd/sway-config
@@ -1,0 +1,4 @@
+exec "gsettings set org.gnome.desktop.a11y.applications screen-keyboard-enabled true"
+exec "squeekboard"
+exec "gtkgreet -l; swaymsg exit"
+include /etc/sway/config.d/*


### PR DESCRIPTION
Required packages:
- greetd
- gtkgreet
- squeekboard
- sway
- libglib2.0-bin (for gsettings)

Alternative sessions (e.g. sway) should be appended to /etc/greetd/environments
for gtkgreet to pick up.

Remaining tasks:
- [x] Gnome logout does not seem to work. Perhaps some environment variables are missing
- [ ] Add this to the pipeline
