### PR TITLE
Linking to raw partition table txt to prevent save link issue

### DIFF
--- a/partition_tables/Readme.md
+++ b/partition_tables/Readme.md
@@ -31,7 +31,7 @@ This approach, if successfull, allows you to flash a new operating system to the
 
 * Preparation:
   
-	* Download the new partition table file (from this repository): [partition_table_standard2.txt](partition_table_standard2.txt)
+	* Download the new partition table file (from this repository): [partition_table_standard2.txt](https://raw.githubusercontent.com/PNDeb/pinenote-debian-image/trixie/partition_tables/partition_table_standard2.txt)
 	* From the latest release (or latest CI build), download the following artifacts:
 	 * the spl loader:
 	   * **rk356x_spl_loader_v1.12.112.bin**


### PR DESCRIPTION
The partition table file link goes to the Github page (html) and not the raw (txt) file so if a person unfamiliar with Github is following instructions right clicks and saves the link they'll save the html and the rkdeveloptool won't be able to parse it causing an unintuitive error. This patch proposes linking directly to the raw file to prevent this issue. 

`Maintenance burden`: when these instructions are merged into main, the link would be need to be updated. I understand if that's a deal breaker and I'd be happy to amend this PR for more verbose instructions instead.