### PR TITLE
fix builds after PNDeb/pinenote-tweaks#5

### DIFF
--- a/04_fix_root_partition.yaml
+++ b/04_fix_root_partition.yaml
@@ -16,7 +16,7 @@ actions:
     chroot: true
     command: |
       echo ${partition_nr}
-      sed -i 's/U_BOOT_ROOT="root=\/dev\/mmcblk0p5"/U_BOOT_ROOT="root=\/dev\/mmcblk0p{{ $target_root_partition }}"/' /usr/share/u-boot-menu/conf.d/u-boot-pinenote.conf
+      sed -i '$a U_BOOT_ROOT="root=\/dev\/mmcblk0p{{ $target_root_partition }}"' /usr/share/u-boot-menu/conf.d/u-boot-pinenote.conf
 
   - action: run
     description: re-generate u-boot menu


### PR DESCRIPTION
In PNDeb/pinenote-tweaks#5, U_BOOT_ROOT was removed so it won't be changed after updating pinenote-basic-support, but we still need it for building images.

See PNDeb/pinenote-debian-image#122